### PR TITLE
Fix distorted post images

### DIFF
--- a/themes/meme/assets/scss/layout/_single.scss
+++ b/themes/meme/assets/scss/layout/_single.scss
@@ -41,6 +41,7 @@
         max-width: 100%;
         border: 1px solid var(--color-contrast-lower);
         clear: both;
+        height: auto;
     }
     video {
         display: block;


### PR DESCRIPTION
Hi! Noticed your post images are stretched out on small screen sizes:

![Screenshot of a blog post with images stretched vertically](https://github.com/palant/palant.info/assets/1672206/8c0b1733-0b0f-4c02-a34a-152d93bcb9ea)

What they'll look like after this PR[^disclaimer]:

![Screenshot of a blog post with correctly proportioned images](https://github.com/palant/palant.info/assets/1672206/d59bc8a6-19ff-4525-9c89-29b87dca3459)

[^disclaimer]: Well, probably - I didn't actually build the site, I just made this edit in the inspector and then copied that into the web version of VSCode that's built into Github. 